### PR TITLE
Very basic Pax header writer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use crate::entry::{Entry, Unpacked};
 pub use crate::entry_type::EntryType;
 pub use crate::header::GnuExtSparseHeader;
 pub use crate::header::{GnuHeader, GnuSparseHeader, Header, HeaderMode, OldHeader, UstarHeader};
-pub use crate::pax::{PaxExtension, PaxExtensions};
+pub use crate::pax::{PaxExtension, PaxExtensions, PaxBuilder, BuilderExt};
 
 mod archive;
 mod builder;

--- a/src/pax.rs
+++ b/src/pax.rs
@@ -166,6 +166,7 @@ impl PaxBuilder {
     }
 
     /// Add a key/value pair to the extended header.
+    ///
     /// It writes the key/value pair in data Vec to be written to the archive.
     pub fn add(&mut self, key: &str, value: &str) {
         self.updated = true;
@@ -201,14 +202,14 @@ pub trait BuilderExt {
 impl<T: Write> BuilderExt for crate::Builder<T> {
     /// Append PAX extended headers to the archive.
     fn append_pax_extensions(&mut self, headers: &PaxBuilder) -> Result<(), io::Error> {
-        /// Ignore the header if it's empty.
+        // Ignore the header if it's empty.
         if !headers.updated() {
             return Ok(())
         }
 
-        /// Create a header of type XHeader, set the size to the length of the
-        /// data, set the entry type to XHeader, and set the checksum
-        /// then append the header and the data to the archive.
+        // Create a header of type XHeader, set the size to the length of the
+        // data, set the entry type to XHeader, and set the checksum
+        // then append the header and the data to the archive.
         let mut header = crate::Header::new_ustar();
         header.set_size(headers.as_bytes().len() as u64);
         header.set_entry_type(crate::EntryType::XHeader);

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -6,12 +6,12 @@ extern crate xattr;
 
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::io::{self, Cursor};
+use std::io::{self, BufWriter, Cursor};
 use std::iter::repeat;
 use std::path::{Path, PathBuf};
 
 use filetime::FileTime;
-use tar::{Archive, Builder, Entries, EntryType, Header, HeaderMode};
+use tar::{Archive, Builder, BuilderExt, Entries, Entry, EntryType, Header, HeaderMode, PaxBuilder};
 use tempfile::{Builder as TempBuilder, TempDir};
 
 macro_rules! t {
@@ -923,6 +923,38 @@ fn pax_simple() {
     assert_eq!(second.value(), Ok("1453251915.24892486"));
     assert_eq!(third.key(), Ok("ctime"));
     assert_eq!(third.value(), Ok("1453146164.953123768"));
+}
+
+#[test]
+fn pax_simple_write() {
+    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
+    let pax_path = td.path().join("pax.tar");
+    let file: File = t!(File::create(&pax_path));
+    let mut ar: Builder<BufWriter<File>> = Builder::new(BufWriter::new(file));
+
+    let mut pax_builder: PaxBuilder = PaxBuilder::new();
+    let key: String = "arbitrary_pax_key".to_string();
+    let value: String = "arbitrary_pax_value".to_string();
+    pax_builder.add(&key, &value);
+
+    t!(ar.append_pax_extensions(&pax_builder));
+    t!(ar.append_file("test2", &mut t!(File::open(&pax_path))));
+    t!(ar.finish());
+    drop(ar);
+
+    let mut archive_opened = Archive::new(t!(File::open(pax_path)));
+    let mut entries = t!(archive_opened.entries());
+    let mut f: Entry<File> = t!(entries.next().unwrap());
+    let pax_headers = t!(f.pax_extensions());
+
+    assert!(pax_headers.is_some(), "pax_headers is None");
+    let mut pax_headers = pax_headers.unwrap();
+    let pax_arbitrary = t!(pax_headers.next().unwrap());
+
+    assert_eq!(pax_arbitrary.key(), Ok("arbitrary_pax_key"));
+    assert_eq!(pax_arbitrary.value(), Ok("arbitrary_pax_value"));
+
+    assert!(entries.next().is_none());
 }
 
 #[test]


### PR DESCRIPTION
Basic implem of PaxBuilder that can add the header with the data provided, implem on tar::builder

Usage:
```rust
let mut pax_builder: PaxBuilder = PaxBuilder::new();

let value: String = "a_value".to_string();
let key: String = "a_key".to_string();

pax_builder.add(&key, &value);

let res_write_pax: Result<(), io::Error> = my_open_tar_archive.append_pax_extensions(&pax_builder);
```